### PR TITLE
Fix warning: unbalanced calls to begin/end appearance transitions

### DIFF
--- a/Cerberus/Classes/MainViewController.swift
+++ b/Cerberus/Classes/MainViewController.swift
@@ -38,27 +38,28 @@ class MainViewController: UIViewController, EKCalendarChooserDelegate {
         setNavbarTitle()
     }
 
+    override func viewDidAppear(animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if self.calendarChooser == nil {
+            presentCalendarChooser()
+        }
+    }
+
     func setNavbarTitle(date: NSDate = NSDate()) {
         self.title = date.stringFromFormat("EEEE, MMMM d, yyyy")
     }
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // FIXME: Unbalanced calls to begin/end appearance transitions
-        presentCalendarChooser()
-    }
-
     func presentCalendarChooser() {
-        let calendarChooser = EKCalendarChooser(
+        self.calendarChooser = EKCalendarChooser(
             selectionStyle: EKCalendarChooserSelectionStyleSingle,
             displayStyle:   EKCalendarChooserDisplayAllCalendars,
             entityType:     EKEntityTypeEvent,
             eventStore:     EKEventStore()
         )
-        calendarChooser.delegate = self
+        self.calendarChooser.delegate = self
 
-        let navigationController = UINavigationController(rootViewController: calendarChooser)
+        let navigationController = UINavigationController(rootViewController: self.calendarChooser)
         self.presentViewController(navigationController, animated: true, completion: nil)
     }
 


### PR DESCRIPTION
## Why

Wanring が出ていた

## What

calendar chooser を present する処理を `viewDidLoad` から `viewDidAppear` に移した